### PR TITLE
Add craftax library and make library forward compatible with latest JAX versions

### DIFF
--- a/install.md
+++ b/install.md
@@ -24,11 +24,25 @@ see guide at: https://jax.readthedocs.io/en/latest/installation.html
 ```
 pip install -U "jax==0.4.20"  "jaxlib==0.4.20"
 ```
+This installs an older JAX version that has been tested to work.
+
+
+**pip install for latest jax:**
+```
+pip install -U "jax[cpu]"
+```
+This installs the latest JAX version and pulls in the dependencies for Jaxlib. Jax install also pulls its own cuda related dependencies so make sure that existing cuda installation is not recognized. The LD_LIBRAR_PATH and PATH environment variables should not contain cuda related paths for existing cuda installations.
 
 **test jax install**
 ```
 TF_CPP_MIN_LOG_LEVEL=0 python -c "import jax; print(f'GPUS: {jax.device_count()}'); jax.random.split(jax.random.PRNGKey(42), 2); print('hello world');"
 ```
+
+**install other requirements**
+```
+pip install -r requirements.txt
+```
+This installs other pacakges that are needed for experiments.
 
 ## Installing other libraries
 

--- a/projects/humansf/alphazero.py
+++ b/projects/humansf/alphazero.py
@@ -63,7 +63,7 @@ def make_agent(
         env: environment.Environment,
         env_params: environment.EnvParams,
         example_timestep: TimeStep,
-        rng: jax.random.KeyArray,
+        rng: jax.Array,
         test_env_params: environment.EnvParams,
         ) -> Tuple[nn.Module, Params, vbb.AgentResetFn]:
 

--- a/projects/humansf/keyroom.py
+++ b/projects/humansf/keyroom.py
@@ -119,7 +119,7 @@ class TaskRunner(struct.PyTreeNode):
         return jnp.concatenate((grid, padding), axis=-1)
 
     # add dimension with all 1s, since each position here is visible to agent
-    visible_grid = add_visibility_pickup(visible_grid)  
+    visible_grid = add_visibility_pickup(visible_grid)
 
     # acc_in_grid is [num_tasks, num_task_objects]
     acc_in_grid = accomplished_HW(visible_grid, self.task_objects)
@@ -268,15 +268,15 @@ def get_local_agent_position(agent_pos, height, width):
     # Calculate the room size
     room_height = height // 3
     room_width = width // 3
-    
+
     # Calculate the room indices
     room_y = agent_pos[0] // room_height
     room_x = agent_pos[1] // room_width
-    
+
     # Calculate the starting coordinates of the room
     start_x = room_x * room_width
     start_y = room_y * room_height
-    
+
     # Calculate the local position within the room
     local_y = agent_pos[0] - start_y
     local_x = agent_pos[1] - start_x
@@ -352,7 +352,7 @@ def render_room(state: EnvState, render_mode: str = "rgb_array", **kwargs):
     return render(room_grid, localized_agent, **kwargs)
   elif render_mode == "rich_text":
     return text_render(room_grid, localized_agent, **kwargs)
-  else: 
+  else:
      raise NotImplementedError(render_mode)
 
 def prepare_task_variables(maze_config: struct.PyTreeNode):
@@ -792,8 +792,8 @@ class KeyRoom(Environment[KeyRoomEnvParams, EnvCarry]):
 
     @partial(jax.jit, static_argnums=(0,))
     def reset(
-       self, 
-       key: jax.random.KeyArray,
+       self,
+       key: jax.Array,
        params: EnvParamsT) -> TimeStep[EnvCarryT]:
         state = self._generate_problem(params, key)
 
@@ -878,7 +878,7 @@ class KeyRoom(Environment[KeyRoomEnvParams, EnvCarry]):
         )
 
     def take_action(self,
-             key: jax.random.KeyArray,
+             key: jax.Array,
              timestep: TimeStep[EnvCarryT],
              action: IntOrArray,
              params: EnvParamsT,
@@ -897,7 +897,7 @@ class KeyRoom(Environment[KeyRoomEnvParams, EnvCarry]):
 
     @partial(jax.jit, static_argnums=(0,))
     def step(self,
-             key: jax.random.KeyArray,
+             key: jax.Array,
              timestep: TimeStep[EnvCarryT],
              action: IntOrArray,
              params: EnvParamsT,

--- a/projects/humansf/minigrid_common.py
+++ b/projects/humansf/minigrid_common.py
@@ -39,7 +39,7 @@ def position_to_two_hot(local_agent_position, grid_shape):
     # Initialize one-hot vectors
     one_hot_x = jnp.zeros(max_x)
     one_hot_y = jnp.zeros(max_y)
-    
+
     # Set the corresponding positions to 1
     one_hot_x = one_hot_x.at[x].set(1)
     one_hot_y = one_hot_y.at[y].set(1)
@@ -94,7 +94,7 @@ class AutoResetWrapper(Wrapper):
         return self._env.reset(key_, params)
 
     def step(self,
-             key: jax.random.KeyArray,
+             key: jax.Array,
              prior_timestep,
              action,
              params):

--- a/projects/humansf/networks.py
+++ b/projects/humansf/networks.py
@@ -125,3 +125,7 @@ class KeyroomObsEncoder(nn.Module):
            self.num_joint_layers)(outputs)
 
         return outputs
+
+class CraftaxObsEncoder(nn.Module):
+    def __init__(self):
+        pass

--- a/projects/humansf/offtask_dyna.py
+++ b/projects/humansf/offtask_dyna.py
@@ -72,10 +72,10 @@ def simulate_n_trajectories(
         num_simulations: int = 5,
     ):
     """
-    
+
     return predictions and actions for every time-step including the current one.
 
-    This first applies the model to the current time-step and then simulates T more time-steps. 
+    This first applies the model to the current time-step and then simulates T more time-steps.
     Output is num_steps+1.
 
     Args:
@@ -541,7 +541,7 @@ def learner_log_extra(
         ):
 
     def log_data(
-        key: str, 
+        key: str,
         timesteps: TimeStep,
         actions: np.array,
         td_errors: np.array,
@@ -739,7 +739,7 @@ class DynaAgentEnvModel(nn.Module):
         """Initializes the RNN state."""
         return self.rnn.initialize_carry(*args, **kwargs)
 
-    def __call__(self, rnn_state, x: TimeStep, rng: jax.random.KeyArray) -> Tuple[Predictions, RnnState]:
+    def __call__(self, rnn_state, x: TimeStep, rng: jax.Array) -> Tuple[Predictions, RnnState]:
 
         embedding = self.observation_encoder(x.observation)
 
@@ -757,7 +757,7 @@ class DynaAgentEnvModel(nn.Module):
 
         return predictions, new_rnn_state
 
-    def unroll(self, rnn_state, xs: TimeStep, rng: jax.random.KeyArray) -> Tuple[Predictions, RnnState]:
+    def unroll(self, rnn_state, xs: TimeStep, rng: jax.Array) -> Tuple[Predictions, RnnState]:
         # rnn_state: [B]
         # xs: [T, B]
 
@@ -783,20 +783,20 @@ class DynaAgentEnvModel(nn.Module):
           self,
           state: AgentState,
           action: jnp.ndarray,
-          rng: jax.random.KeyArray,
+          rng: jax.Array,
       ) -> Tuple[Predictions, RnnState]:
         """This applies the model to each element in the state, action vectors.
         Args:
             state (State): states. [B, D]
             action (jnp.ndarray): actions to take on states. [B]
         Returns:
-            Tuple[ModelOutput, State]: muzero outputs and new states for 
+            Tuple[ModelOutput, State]: muzero outputs and new states for
               each state state action pair.
         """
         # take one step forward in the environment
         B = action.shape[0]
         rng, rng_ = jax.random.split(rng)
-        def env_step(s, a, rng_): 
+        def env_step(s, a, rng_):
            return self.env.step(rng_, s.timestep, a, self.env_params)
         next_timestep = jax.vmap(env_step)(
             state, action, jax.random.split(rng_, B))
@@ -810,14 +810,14 @@ class DynaAgentEnvModel(nn.Module):
         self,
         state: AgentState,
         actions: jnp.ndarray,
-        rng: jax.random.KeyArray,
+        rng: jax.Array,
     ) -> Tuple[Predictions, RnnState]:
         """This applies the model recursively to the state using the sequence of actions.
         Args:
             state (State): states. [B, D]
             action (jnp.ndarray): actions to take on states. [T, B]
         Returns:
-            Tuple[ModelOutput, State]: muzero outputs and new states for 
+            Tuple[ModelOutput, State]: muzero outputs and new states for
               each state state action pair.
         """
 
@@ -845,7 +845,7 @@ def make_agent(
         env: environment.Environment,
         env_params: environment.EnvParams,
         example_timestep: TimeStep,
-        rng: jax.random.KeyArray,
+        rng: jax.Array,
         model_env_params: environment.EnvParams,
         ) -> Tuple[nn.Module, Params, vbb.AgentResetFn]:
 

--- a/projects/humansf/qlearning.py
+++ b/projects/humansf/qlearning.py
@@ -72,7 +72,7 @@ class RnnAgent(nn.Module):
 
         return self(rnn_state, x, rng)
 
-    def __call__(self, rnn_state, x: TimeStep, rng: jax.random.KeyArray):
+    def __call__(self, rnn_state, x: TimeStep, rng: jax.Array):
 
         embedding = self.observation_encoder(x.observation)
 
@@ -84,7 +84,7 @@ class RnnAgent(nn.Module):
 
         return Predictions(q_vals, rnn_out), new_rnn_state
 
-    def unroll(self, rnn_state, xs: TimeStep, rng: jax.random.KeyArray):
+    def unroll(self, rnn_state, xs: TimeStep, rng: jax.Array):
         # rnn_state: [B]
         # xs: [T, B]
 
@@ -107,7 +107,7 @@ def make_agent(
         env: environment.Environment,
         env_params: environment.EnvParams,
         example_timestep: TimeStep,
-        rng: jax.random.KeyArray) -> Tuple[Agent, Params, vbb.AgentResetFn]:
+        rng: jax.Array) -> Tuple[Agent, Params, vbb.AgentResetFn]:
 
     cell_type = config.get('RNN_CELL_TYPE', 'OptimizedLSTMCell')
     if cell_type.lower() == 'none':

--- a/requirements-2.txt
+++ b/requirements-2.txt
@@ -1,3 +1,14 @@
 typing_extensions==4.11.0
 optax==0.2.1
 scipy==1.12.0
+wandb==0.17.0
+ray==2.23.0
+hydra-core==1.3.2
+gymnax==0.0.8
+safetensors==0.4.3
+craftax==1.4.2
+flashbax==0.1.2
+rlax==0.1.6
+mctx==0.0.5
+ray[tune]
+ipdb==0.13.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,8 @@ tqdm
 rlax
 mctx
 ray[tune]
+hydra-core
+gymnax
+safetensors
+flashbax
+craftax

--- a/singleagent/baselines.py
+++ b/singleagent/baselines.py
@@ -59,6 +59,7 @@ gymnax_envs = ['CartPole-v1',
        'Catch-bsuite']
 craftax_envs = ['Craftax-Symbolic-v1']
 
+# Call run_single
 def run_single(
         config: dict,
         save_path: str = None):
@@ -76,8 +77,6 @@ def run_single(
       basic_env = make_craftax_env_from_name(config['ENV_NAME'], auto_reset=True)
       env_params = basic_env.default_params
 
-    import pdb
-    pdb.set_trace()
     env = FlattenObservationWrapper(basic_env)
 
     # converts to using timestep

--- a/singleagent/qlearning.py
+++ b/singleagent/qlearning.py
@@ -44,7 +44,7 @@ RNNInput = vbb.RNNInput
 class R2D2LossFn(vbb.RecurrentLossFn):
 
   """Loss function of R2D2.
-  
+
   https://openreview.net/forum?id=r1lyTjAqYX
   """
 
@@ -242,7 +242,7 @@ class RnnAgent(nn.Module):
         """Initializes the RNN state."""
         return self.rnn.initialize_carry(*args, **kwargs)
 
-    def __call__(self, rnn_state, x: TimeStep, rng: jax.random.KeyArray):
+    def __call__(self, rnn_state, x: TimeStep, rng: jax.Array):
         x = extract_timestep_input(x)
 
         embedding = self.observation_encoder(x.obs)
@@ -256,7 +256,7 @@ class RnnAgent(nn.Module):
 
         return Predictions(q_vals, rnn_out), new_rnn_state
 
-    def unroll(self, rnn_state, xs: TimeStep, rng: jax.random.KeyArray):
+    def unroll(self, rnn_state, xs: TimeStep, rng: jax.Array):
         # rnn_state: [B]
         # xs: [T, B]
         xs = extract_timestep_input(xs)
@@ -291,7 +291,7 @@ class LinearDecayEpsilonGreedy:
 
         def explore(q, eps, key):
             key_a, key_e   = jax.random.split(key, 2) # a key for sampling random actions and one for picking
-            greedy_actions = jnp.argmax(q, axis=-1) # get the greedy actions 
+            greedy_actions = jnp.argmax(q, axis=-1) # get the greedy actions
             random_actions = jax.random.randint(key_a, shape=greedy_actions.shape, minval=0, maxval=q.shape[-1]) # sample random actions
             pick_random    = jax.random.uniform(key_e, greedy_actions.shape)<eps # pick which actions should be random
             chosed_actions = jnp.where(pick_random, random_actions, greedy_actions)
@@ -312,7 +312,7 @@ class FixedEpsilonGreedy:
 
         def explore(q, eps, key):
             key_a, key_e   = jax.random.split(key, 2) # a key for sampling random actions and one for picking
-            greedy_actions = jnp.argmax(q, axis=-1) # get the greedy actions 
+            greedy_actions = jnp.argmax(q, axis=-1) # get the greedy actions
             random_actions = jax.random.randint(key_a, shape=greedy_actions.shape, minval=0, maxval=q.shape[-1]) # sample random actions
             pick_random    = jax.random.uniform(key_e, greedy_actions.shape)<eps # pick which actions should be random
             chosed_actions = jnp.where(pick_random, random_actions, greedy_actions)
@@ -326,7 +326,7 @@ def make_rnn_agent(
         env: environment.Environment,
         env_params: environment.EnvParams,
         example_timestep: TimeStep,
-        rng: jax.random.KeyArray) -> Tuple[nn.Module, Params, vbb.AgentResetFn]:
+        rng: jax.Array) -> Tuple[nn.Module, Params, vbb.AgentResetFn]:
 
     agent = RnnAgent(
         action_dim=env.action_space(env_params).n,
@@ -355,7 +355,7 @@ def make_mlp_agent(
         env: environment.Environment,
         env_params: environment.EnvParams,
         example_timestep: TimeStep,
-        rng: jax.random.KeyArray) -> Tuple[nn.Module, Params, vbb.AgentResetFn]:
+        rng: jax.Array) -> Tuple[nn.Module, Params, vbb.AgentResetFn]:
 
     agent = RnnAgent(
         action_dim=env.action_space(env_params).n,
@@ -394,19 +394,19 @@ def make_loss_fn_class(config) -> vbb.RecurrentLossFn:
      R2D2LossFn,
      discount=config['GAMMA'])
 
-def make_actor(config: dict, agent: Agent, rng: jax.random.KeyArray) -> vbb.Actor:
+def make_actor(config: dict, agent: Agent, rng: jax.Array) -> vbb.Actor:
     fixed_epsilon = config.get('FIXED_EPSILON', 1)
     assert fixed_epsilon in (0, 1, 2)
     if fixed_epsilon:
         ## BELOW was copied from ACME
-        if fixed_epsilon == 1: 
+        if fixed_epsilon == 1:
             vals = np.logspace(
                     start=config.get('EPSILON_MIN', 1),
                     stop=config.get('EPSILON_MAX', 3),
                     num=config.get('NUM_EPSILONS', 256),
                     base=config.get('EPSILON_BASE', .1))
         else:
-            # BELOW is in range of ~(.9,.1) 
+            # BELOW is in range of ~(.9,.1)
             vals = np.logspace(
                     num=config.get('NUM_EPSILONS', 256),
                     start=config.get('EPSILON_MIN', .05),
@@ -427,7 +427,7 @@ def make_actor(config: dict, agent: Agent, rng: jax.random.KeyArray) -> vbb.Acto
         train_state: vbb.TrainState,
         agent_state: jax.Array,
         timestep: TimeStep,
-        rng: jax.random.KeyArray):
+        rng: jax.Array):
         preds, agent_state = agent.apply(
             train_state.params, agent_state, timestep, rng)
 
@@ -440,7 +440,7 @@ def make_actor(config: dict, agent: Agent, rng: jax.random.KeyArray) -> vbb.Acto
         train_state: vbb.TrainState,
         agent_state: jax.Array,
         timestep: TimeStep,
-        rng: jax.random.KeyArray):
+        rng: jax.Array):
         preds, agent_state = agent.apply(
             train_state.params, agent_state, timestep, rng)
 


### PR DESCRIPTION
* Add craftax dependency to requirements.
* Replaces `jax.random.KeyArray` with `jax.Array` as the former is deprecated in latest JAX versions.
* Adds documentation for installing the latest Jax versions with GPU support.
* Documents caveats for using JAX provided CUDA libraries instead of system cuda libraries which can cause incompatibility.